### PR TITLE
Deprecating userList

### DIFF
--- a/dissectBCL.ini
+++ b/dissectBCL.ini
@@ -18,7 +18,7 @@ pushURL=parkour.push.url/api
 user=parkourUser
 password=parkourPw
 cert=/path/to/cert.pem
-userList=filename_with_parkour_users
+URL=parkour.domain.tld
 
 [software]
 bclconvert=/path/to/bclconvert

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -68,9 +68,7 @@ Note that this block contains sensitive information.
 #. user: the username for API requests
 #. pw: the password for API requests
 #. cert: the pem certificate for API requests
-#. userList: a headerless tsv file containing firstname lastname emailaddress lines.
-
-Note that the userList is used implicitly for the email command to notify end users.
+#. URL: the URL to Parkour2, `https://` is implicit!
 
 .. _software:
 
@@ -128,7 +126,7 @@ example
     user=parkourUser
     password=parkourPw
     cert=/path/to/cert.pem
-    userList=filename_with_parkour_users
+    URL=parkour.domain.tld
 
     [software]
     bclconvert=/path/to/bclconvert


### PR DESCRIPTION
This code needs to be tested (e.g. `args.project[0].split("_")[1]`, passed to the new function that replaces `fetchFirstNameAndEmail` should be the 4-digit project ID).

**The new API endpoint is yet to be deployed to production.** I'm only opening the PR as a draft on the functionality that we'll be able to use soon.