### PR TITLE
pytest updates

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,14 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: mamba-org/setup-micromamba@main
+      - uses: conda-incubator/setup-miniconda@v3
         with:
+          channels: conda-forge,bioconda
+          channel-priority: true
           environment-file: env.yml
           cache-downloads: true
           environment-name: dissectBCL
+          activate-environment: dissectBCL
       - name: build docs
         run: |
-          micromamba activate dissectBCL
           pip install .[docs]
           cd docs
           make html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,7 @@ jobs:
           cache-downloads: true
           environment-name: dissectBCL
           activate-environment: dissectBCL
+          conda-remove-defaults: true
       - name: build docs
         run: |
           pip install .[docs]

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,17 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: mamba-org/setup-micromamba@main
+      - uses: conda-incubator/setup-miniconda@v3
         with:
+          channels: conda-forge,bioconda
+          channel-priority: true
           environment-file: env.yml
           cache-downloads: true
           environment-name: dissectBCL
-      - name: build
+          activate-environment: dissectBCL
+      - name: pip
         run: |
-          micromamba activate dissectBCL
           pip install .[dev]
       - name: pytest
         run: |
-          micromamba activate dissectBCL
-          coverage run -m pytest
-          coverage report -m
+          pytest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,6 +23,7 @@ jobs:
           cache-downloads: true
           environment-name: dissectBCL
           activate-environment: dissectBCL
+          conda-remove-defaults: true
       - name: pip
         run: |
           pip install .[dev]

--- a/contaminome.yml
+++ b/contaminome.yml
@@ -76,12 +76,12 @@ prokaryotes:
    accession: GCF_001186195.1
    taxid: 47880
   Pseudomonas fluorescens:
-    URL: https://raw.githubusercontent.com/maxplanck-ie/customcontamination/main/pseudomonas_fluorescens.fna.gz
+    URL: https://github.com/maxplanck-ie/customcontamination/raw/refs/heads/main/fna/pseudomonas_fluorescens.fna.gz
     vulgarname: pseudomonas-fluorescens
     accession: GCF_900215245.1
     taxid: 294
   Pseudomonas yamanorum:
-    URL: https://raw.githubusercontent.com/maxplanck-ie/customcontamination/main/pseudomonas_yamanorum.fna.gz
+    URL: https://github.com/maxplanck-ie/customcontamination/raw/refs/heads/main/fna/pseudomonas_yamanorum.fna.gz
     vulgarname: pseudomonas-yamanorum
     accession: GCF_900105735.1
     taxid: 515393
@@ -127,94 +127,94 @@ custom:
    accession: GCF_000864005.1
    taxid: 11983
   Influenza B:
-   URL: https://raw.githubusercontent.com/WardDeb/customcontamination/main/fna/influenzab.fna.gz
+   URL: https://raw.githubusercontent.com/maxplanck-ie/customcontamination/main/fna/influenzab.fna.gz
    vulgarname: flu-b
    accession: NC_002211.1
    taxid: 11520
   Rhinovirus A:
-   URL: https://raw.githubusercontent.com/WardDeb/customcontamination/main/fna/rhinoa.fna.gz
+   URL: https://raw.githubusercontent.com/maxplanck-ie/customcontamination/main/fna/rhinoa.fna.gz
    vulgarname: common-cold-a
    accession: NC_038311.1
    taxid: 573824
   Rhinovirus B:
-   URL: https://raw.githubusercontent.com/WardDeb/customcontamination/main/fna/rhinob.fna.gz
+   URL: https://raw.githubusercontent.com/maxplanck-ie/customcontamination/main/fna/rhinob.fna.gz
    vulgarname: common-cold-b
    accession: NC_001490.1
    taxid: 12131
   Drosophila C virus:
-    URL: https://raw.githubusercontent.com/WardDeb/customcontamination/main/fna/drosophilac.fna.gz
+    URL: https://raw.githubusercontent.com/maxplanck-ie/customcontamination/main/fna/drosophilac.fna.gz
     vulgarname: drosophila-c-virus
     accession: NC_001834.1
     taxid: 64279
   Escherichia phage phiX174:
-   URL: https://raw.githubusercontent.com/WardDeb/customcontamination/main/fna/phix.fna.gz
+   URL: https://raw.githubusercontent.com/maxplanck-ie/customcontamination/main/fna/phix.fna.gz
    vulgarname: phix
    accession: NC_001422.1
    taxid: 2886930
   Enterobacteria phage lambda:
-   URL: https://raw.githubusercontent.com/WardDeb/customcontamination/main/fna/lambdaphage.fna.gz
+   URL: https://raw.githubusercontent.com/maxplanck-ie/customcontamination/main/fna/lambdaphage.fna.gz
    vulgarname: lambdaphage
    accession: NC_001416.1
    taxid: 10710
   UniVec_core:
-    URL: https://raw.githubusercontent.com/WardDeb/customcontamination/main/fna/univec_core.fna.gz
+    URL: https://raw.githubusercontent.com/maxplanck-ie/customcontamination/main/fna/univec_core.fna.gz
     vulgarname: vectors
     accession: NA
     taxid: 29278
   ERCC:
-    URL: https://raw.githubusercontent.com/WardDeb/customcontamination/main/fna/ercc.fna.gz
+    URL: https://raw.githubusercontent.com/maxplanck-ie/customcontamination/main/fna/ercc.fna.gz
     vulgarname: ercc
     accession: NA
     taxid: 292781111
 rrna:
   Homo sapiens pre-rRNA:
-   URL: https://raw.githubusercontent.com/WardDeb/customcontamination/main/fna/human45s.fna.gz
+   URL: https://raw.githubusercontent.com/maxplanck-ie/customcontamination/main/fna/human45s.fna.gz
    vulgarname: humanrrna
    accession: NR_046235.3
    taxid: 96061111
   Mus musculus pre-rRNA:
-   URL: https://raw.githubusercontent.com/WardDeb/customcontamination/main/fna/mouse45s.fna.gz
+   URL: https://raw.githubusercontent.com/maxplanck-ie/customcontamination/main/fna/mouse45s.fna.gz
    vulgarname: mouserrna
    accession: NR_046233.2
    taxid: 100901111
   Drosophila melanogaster pre-rRNA:
-   URL: https://raw.githubusercontent.com/WardDeb/customcontamination/main/fna/fly45s.fna.gz
+   URL: https://raw.githubusercontent.com/maxplanck-ie/customcontamination/main/fna/fly45s.fna.gz
    vulgarname: flyrrna
    accession: NR_133549.1
    taxid: 72271111
   Aedes aegypti 28SrRNA:
-   URL: https://raw.githubusercontent.com/WardDeb/customcontamination/main/fna/aedesaegypti28s.fna.gz
+   URL: https://raw.githubusercontent.com/maxplanck-ie/customcontamination/main/fna/aedesaegypti28s.fna.gz
    vulgarname: aedesaegyptirrna
    accession: NC_035159.1
    taxid: 71591111
   Zebrafish rRNA:
-    URL: https://raw.githubusercontent.com/WardDeb/customcontamination/main/fna/zebrarRNA.fna.gz
+    URL: https://raw.githubusercontent.com/maxplanck-ie/customcontamination/main/fna/zebrarRNA.fna.gz
     vulgarname: zebrafishrrna
     accession: NR_145818.1
     taxid: 79551111
 mito:
   Homo sapiens mitochondrion:
-   URL: https://raw.githubusercontent.com/WardDeb/customcontamination/main/fna/humanmito.fna.gz
+   URL: https://raw.githubusercontent.com/maxplanck-ie/customcontamination/main/fna/humanmito.fna.gz
    vulgarname: humanmito
    accession: NC_012920.1
    taxid: 96062222
   Mus musculus mitochondrion:
-   URL: https://raw.githubusercontent.com/WardDeb/customcontamination/main/fna/mousemito.fna.gz
+   URL: https://raw.githubusercontent.com/maxplanck-ie/customcontamination/main/fna/mousemito.fna.gz
    vulgarname: mousemito
    accession: NC_005089.1
    taxid: 100902222
   Drosophila melanogaster mitochondrion:
-     URL: https://raw.githubusercontent.com/WardDeb/customcontamination/main/fna/flymito.fna.gz
+     URL: https://raw.githubusercontent.com/maxplanck-ie/customcontamination/main/fna/flymito.fna.gz
      vulgarname: flymito
      accession: NC_024511.2
      taxid: 72272222
   Aedes aegypti mitochondrion: 
-     URL: https://raw.githubusercontent.com/WardDeb/customcontamination/main/fna/aedesaegyptimito.fna.gz
+     URL: https://raw.githubusercontent.com/maxplanck-ie/customcontamination/main/fna/aedesaegyptimito.fna.gz
      vulgarname: aedesaegyptimito
      accession: NC_035159.1
      taxid: 71592222
   Zebrafish mitochondrion:
-     URL: https://raw.githubusercontent.com/WardDeb/customcontamination/main/fna/zebramito.fna.gz
+     URL: https://raw.githubusercontent.com/maxplanck-ie/customcontamination/main/fna/zebramito.fna.gz
      vulgarname: zebrafishmito
      accession: NC_002333.2
      taxid: 79552222

--- a/env.yml
+++ b/env.yml
@@ -2,7 +2,7 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - python <=3.12
+  - python >=3.10, <=3.12
   - matplotlib >=3.4
   - pandas >=2.0
   - biopython >=1.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "ruff",
-  "coverage",
   "pytest",
-  "pytest-cov",
   "pytest-datafiles"
 ]
 docs = [

--- a/tests/test_contam.py
+++ b/tests/test_contam.py
@@ -22,6 +22,3 @@ class Test_Contam():
             # responsive
             response = requests.head(_link, allow_redirects=True, timeout=10)
             assert response.status_code == 200, f"URL not reachable (status {response.status_code}): {_link}"
-    
-    def test_failure(self):
-        assert False

--- a/tests/test_contam.py
+++ b/tests/test_contam.py
@@ -1,0 +1,27 @@
+import yaml
+from urllib.parse import urlparse
+import requests
+
+class Test_Contam():
+    def test_links(self):
+        # contam is a function that is not yet implemented
+        with open("contaminome.yml") as f:
+            genomes = yaml.safe_load(f)
+        _links = []
+        for gtype in genomes:
+            for genome in genomes[gtype]:
+                _links.append(
+                    genomes[gtype][genome]['URL']
+                )
+        for _link in _links:
+            _lp = urlparse(_link)
+            # https link
+            assert _lp.scheme == 'https', f"URL is not an https link: {_link}"
+            # Domain not empty
+            assert _lp.netloc, f"URL seems to not have a domain: {_link}"
+            # responsive
+            response = requests.head(_link, allow_redirects=True, timeout=10)
+            assert response.status_code == 200, f"URL not reachable (status {response.status_code}): {_link}"
+    
+    def test_failure(self):
+        assert False

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -4,7 +4,6 @@ from dissectBCL.misc import joinLis
 from dissectBCL.misc import hamming
 from dissectBCL.misc import lenMask
 from dissectBCL.misc import P5Seriesret
-from dissectBCL.misc import moveOptDup
 from dissectBCL.misc import retBCstr
 from dissectBCL.misc import retIxtype
 from dissectBCL.misc import retMean_perc_Q
@@ -138,14 +137,6 @@ class Test_misc_Files():
             'test_misc',
             testFile
         )
-
-    def test_moveOptDup(self):
-        moveOptDup(self.RTF('myLane'))
-        _file_in = "myLane/x1/x2/x3_duplicate.txt"
-        _file_out = "myLane/FASTQC_x1/x2/x3_duplicate.txt"
-        assert os.path.exists(self.RTF(_file_out))
-        os.rename(self.RTF(_file_out), self.RTF(_file_in))
-        assert os.path.exists(self.RTF(_file_in))
 
     def test_parseRunInfo(self):
         _runInfo = parseRunInfo(


### PR DESCRIPTION
- Simplify pytest setup
- ensure actions fail if pytest fail
- include test for links in contaminome.yaml
- drop mamba from actions
- drop deprecated 'moveoptdups' test
- fix broken links in default contaminome