### PR TITLE
fix: clear error for emailProjectFinished on externally-fexed projects

### DIFF
--- a/src/tools/emailProjectFinished.py
+++ b/src/tools/emailProjectFinished.py
@@ -36,15 +36,34 @@ def getProjectIDs(projects, config):
         IDs.append(p.split("_")[1])
         # compound surnames use minus, we use 1st only.
         PI = p.split("_")[-1].split("-")[0].lower()
+    # Internal vs external PIs are shipped differently (see wd40's
+    # fetchFolders): external PIs only get their fastqs fex'ed and never
+    # get an internal sequencing_data directory, so there is nothing here
+    # for this tool to point users at yet.
+    if PI not in config["Internals"]["PIs"]:
+        sys.exit(
+            f"PI '{PI}' is not in the internal PI list, so this project was "
+            "likely delivered externally via Fex (same check as 'wd40 rel .' "
+            "does), which doesn't produce an internal sequencing_data "
+            "directory. emailProjectFinished doesn't support externally "
+            "fex'ed projects yet."
+        )
     # Get the actual sequencing_data dir
     # Assume if multiple projects are given, they all in the same flowcell.
     flowcell = getFlowCell()
     # Assume that only a flow cell exists only once.
-    seqdir = glob.glob(
+    matches = glob.glob(
         os.path.join(
             config["Dirs"]["piDir"], PI, config["Internals"]["seqDir"] + "*", flowcell
         )
-    )[0].split("/")[-2]
+    )
+    if not matches:
+        sys.exit(
+            f"No sequencing_data directory found for PI '{PI}' and flowcell "
+            f"'{flowcell}' under {config['Dirs']['piDir']}. Double check the "
+            "project was actually shipped internally."
+        )
+    seqdir = matches[0].split("/")[-2]
 
     if len(IDs) == 1:
         return IDs[0], seqdir


### PR DESCRIPTION
## Summary
- `emailProjectFinished`'s `getProjectIDs()` globbed for an internal PI sequencing_data directory unconditionally, then indexed `[0]` into the (possibly empty) result. Running `email` on a project belonging to a PI outside the internal PI list crashed with an opaque `IndexError: list index out of range` instead of explaining what was wrong.
- `wd40 rel .` already does this exact PI-membership check in `fetchFolders()` before deciding whether to look for an internal seqdir or assume the project was delivered externally via Fex, printing `Assuming {proj} is fex'ed.`
- This applies the same check in `getProjectIDs()`, exiting with a message explaining the project is likely fex'ed externally (same reasoning as `wd40 rel .`), plus a second guard with a clear message if the internal seqdir is still missing for any other reason.

## Test plan
- [x] Reproduced the original crash on rapidus (`email --configfile ... Project_4009_Perez-Jimenez_Guhathakurta`, PI not in the internal PI list) and confirmed it now exits with a clear message instead of a traceback.
- [x] `ruff check` / `ruff format --check` pass on the changed file.
- [ ] CI