### PR TITLE
ci: add workflow_dispatch trigger to release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: {}
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Adds a manual `workflow_dispatch` trigger to the release-please workflow, so it can be re-run on demand instead of only on push to main.

## Why
PR #281 ("release 2.0.0") incorrectly bundled years of already-released commits because the v1.0.3 GitHub Release/tag was never created (a prior run crashed before labeling PR #280 as `autorelease: pending`). I've manually restored the `v1.0.3` tag/release at the correct commit (c3cfc5d). This trigger lets us re-run release-please to confirm it now correctly resumes from v1.0.3 without needing a real feature commit.

## Test plan
- [ ] Merge this PR
- [ ] Manually dispatch the release-please workflow
- [ ] Confirm it opens (or doesn't open) a sane, small release PR based only on commits after v1.0.3 — not a repeat of the 2.0.0 bug