### PR TITLE
chore: Add versioned conda env install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,24 @@ Demultiplexing pipeline for illumina data (novaseq/miseq/nextseq). Continuation 
 
 ## Installation.
 
-Clone this repository, create the environment and pip install
+Clone this repository and run the install script. It creates a version-named
+conda env (e.g. `dissect_v1.0.3`) from the latest git tag and installs
+dissectBCL into it, so the reported version always matches what's running
+and older releases stay available side by side.
 
  > git clone git@github.com:maxplanck-ie/dissectBCL.git  
  > cd dissectBCL  
- > conda env create -f env.yml --name dissectBCL  
- > conda activate dissectBCL  
- > pip install ./  
+ > ./install_dissect.sh  
+ > conda activate dissect_v1.0.3  
+
+Run `./install_dissect.sh` again after pulling a new release (e.g. once
+release-please tags and merges a new version) to create the next versioned
+env; it prunes old envs automatically, keeping the 5 most recent. See
+`./install_dissect.sh -h` for options (specific tag, env prefix, how many
+to keep, force-recreate).
 
 > [!NOTE]
-> If you get `LookupError: setuptools-scm was unable to detect version`. Ensure that git is available on the conda environment you've just activated: `conda install git`.
+> If you get `LookupError: setuptools-scm was unable to detect version`, ensure git is available in the conda environment: `conda install git`.
 
 ## Running.
 

--- a/install_dissect.sh
+++ b/install_dissect.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# install_dissect.sh - create a version-named conda env for dissectBCL and
+# install a tagged release into it non-editably. Not part of the Python
+# package; a local ops convenience script run after pulling a new release.
+#
+# Usage: ./install_dissect.sh [-t <tag>] [-p <prefix>] [-k <n>] [-f] [-h]
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: install_dissect.sh [-t <tag>] [-p <prefix>] [-k <n>] [-f] [-h]
+
+Create a version-named conda env (e.g. dissect_v1.0.4) and install
+dissectBCL into it from a git tag, then prune old versioned envs.
+
+Options:
+  -t <tag>     Install this tag instead of the latest reachable tag
+               (e.g. v1.0.3). Default: latest tag from `git describe`.
+  -p <prefix>  Env name prefix. Default: dissect_v
+  -k <n>       Number of versioned envs to keep (newest first). Default: 5
+  -f           Force: remove the target env first if it already exists.
+  -h           Show this help and exit.
+EOF
+}
+
+prefix="dissect_v"
+keep=5
+tag=""
+force=0
+
+while getopts ":t:p:k:fh" opt; do
+  case "$opt" in
+    t) tag="$OPTARG" ;;
+    p) prefix="$OPTARG" ;;
+    k) keep="$OPTARG" ;;
+    f) force=1 ;;
+    h) usage; exit 0 ;;
+    \?) echo "Unknown option: -$OPTARG" >&2; usage; exit 1 ;;
+    :) echo "Option -$OPTARG requires an argument" >&2; usage; exit 1 ;;
+  esac
+done
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$script_dir"
+
+command -v conda >/dev/null 2>&1 || { echo "conda not found on PATH" >&2; exit 1; }
+command -v git   >/dev/null 2>&1 || { echo "git not found on PATH" >&2; exit 1; }
+[ -d .git ] || { echo "$script_dir is not a git repository" >&2; exit 1; }
+
+git fetch --tags --quiet
+
+if [ -z "$tag" ]; then
+  tag="$(git describe --tags --abbrev=0)"
+fi
+
+if ! git rev-parse "refs/tags/$tag" >/dev/null 2>&1; then
+  echo "Tag '$tag' not found (did you git fetch --tags?)" >&2
+  exit 1
+fi
+
+version="${tag#v}"
+envname="${prefix}${version}"
+
+# Build from a throwaway worktree at the tag rather than checking out this
+# repo in place - avoids touching the caller's working tree (which may hold
+# this very script, absent from older tags) or requiring it to be clean.
+worktree_dir="$(mktemp -d "${TMPDIR:-/tmp}/dissect_install_${version}.XXXXXX")"
+cleanup() { git worktree remove --force "$worktree_dir" >/dev/null 2>&1 || rm -rf "$worktree_dir"; }
+trap cleanup EXIT
+
+echo "Checking out $tag into $worktree_dir..."
+git worktree add --quiet --detach "$worktree_dir" "$tag"
+
+[ -f "$worktree_dir/env.yml" ] || { echo "env.yml not found at $tag" >&2; exit 1; }
+
+env_exists=0
+conda env list | awk '{print $1}' | grep -qx "$envname" && env_exists=1
+
+if [ "$force" -eq 1 ]; then
+  # Unconditional: env listings can lag behind actual env directories on
+  # some shared filesystems, so don't trust env_exists alone to decide
+  # whether removal is needed - just make removal a no-op if absent.
+  echo "Removing existing env $envname (forced, if present)..."
+  conda env remove -n "$envname" --yes >/dev/null 2>&1 || true
+elif [ "$env_exists" -eq 1 ]; then
+  echo "Env '$envname' already exists. Use -f to remove and recreate it." >&2
+  exit 1
+fi
+
+echo "Creating env $envname from env.yml..."
+conda env create -f "$worktree_dir/env.yml" --name "$envname"
+
+echo "Installing dissectBCL $tag into $envname..."
+conda run -n "$envname" pip install "$worktree_dir"
+
+echo "Pruning old '$prefix*' envs, keeping newest $keep..."
+mapfile -t old_envs < <(
+  conda env list | awk '{print $1}' \
+    | grep -E "^${prefix}[0-9]" \
+    | sort -Vr \
+    | tail -n +"$((keep + 1))"
+)
+for old in "${old_envs[@]:-}"; do
+  [ -z "$old" ] && continue
+  echo "Removing old env: $old"
+  conda env remove -n "$old" --yes
+done
+
+cat <<EOF
+
+Installed dissectBCL $tag into env '$envname'.
+To use it: conda activate $envname
+Remember to restart your dissect process in the new env.
+EOF


### PR DESCRIPTION
## Summary
- Adds `install_dissect.sh`: creates a version-named conda env (e.g. `dissect_v1.0.3`) from the latest (or a specified) git tag and installs dissectBCL into it non-editably from a throwaway `git worktree`, so the reported version never goes stale after a `release-please` tag bump.
- Prunes old versioned envs automatically, keeping the 5 most recent (`-k` to override).
- Updates `README.md` installation instructions to use the script instead of manually reusing a single `dissectBCL` env.

Not part of the installed Python package - a local ops convenience script, run after pulling a new release.

## Test plan
Verified end-to-end on a shared conda/NFS host (using a throwaway env prefix, cleaned up after):
- [x] Fresh install of `v1.0.3` creates `<prefix>1.0.3`, installs non-editably, `pip show dissectBCL` reports a clean `1.0.3` (no `.dev+g<hash>`)
- [x] Re-running without `-f` refuses to clobber an existing env
- [x] `-f` removes and recreates the target env
- [x] With 6 versioned envs present, pruning keeps the 5 newest and removes only the oldest
- [x] `bash -n install_dissect.sh` clean