### PR TITLE
feat: ship RO-Crate zip via FEX, replace static PI list, add fastq File entities

### DIFF
--- a/dissectBCL.ini
+++ b/dissectBCL.ini
@@ -9,7 +9,7 @@ bioinfoCoreDir=/path/to/share/qc/with/core
 tempDir=/path/to/tempDir
 
 [Internals]
-PIs=[pi1,pi2,pi3,pi4,pi5]
+Organizations=MPI-IE
 seqDir=seqfolderstr
 fex=False
 

--- a/src/dissectBCL/fakeNews.py
+++ b/src/dissectBCL/fakeNews.py
@@ -313,6 +313,7 @@ def shipFiles(outPath, config):
                     project,
                     config["communication"]["fromAddress"],
                     (projectPath, fqcPath),
+                    config,
                 )
     sendMqcReports(outPath, config["Dirs"])
     transferStop = datetime.datetime.now()

--- a/src/dissectBCL/fakeNews.py
+++ b/src/dissectBCL/fakeNews.py
@@ -263,7 +263,7 @@ def shipFiles(outPath, config):
         logging.info(f"fakenews - Shipping {project}")
         PI = project.split("_")[-1].lower().replace("cabezas-wallscheid", "cabezas")
         fqcPath = Path(str(projectPath).replace("Project_", "FASTQC_Project_"))
-        if PI in config["Internals"]["PIs"]:
+        if PI in config["Internals"]["PIs"].split(","):
             # Shipping
             fqc = fqcPath.name
             enduserBase = fetchLatestSeqDir(config, PI) / outLane

--- a/src/dissectBCL/fakeNews.py
+++ b/src/dissectBCL/fakeNews.py
@@ -21,6 +21,7 @@ from dissectBCL.misc import (
     getDiskSpace,
     joinLis,
     matchOptdupsReqs,
+    projectPI,
     sendMqcReports,
     stripRights,
     umlautDestroyer,
@@ -261,7 +262,7 @@ def shipFiles(outPath, config):
         project = projectPath.name
         shipDic[project] = "No"
         logging.info(f"fakenews - Shipping {project}")
-        PI = project.split("_")[-1].lower().replace("cabezas-wallscheid", "cabezas")
+        PI = projectPI(project)
         fqcPath = Path(str(projectPath).replace("Project_", "FASTQC_Project_"))
         if PI in config["Internals"]["PIs"].split(","):
             # Shipping

--- a/src/dissectBCL/misc.py
+++ b/src/dissectBCL/misc.py
@@ -33,6 +33,7 @@ def _resolve_internal_pis(config, strict=True):
                 f"Parkour's internal_pis endpoint returned {response.status_code}: "
                 f"{response.text}"
             )
+        pi_names = response.json()["pis"]
     except Exception as e:
         # Only the shipping path (quickload=False) makes the internal-vs-external
         # routing decision this list gates, so it fails loudly. Lightweight
@@ -48,7 +49,6 @@ def _resolve_internal_pis(config, strict=True):
             f"endpoint at {url}: {e}. Proceeding with an empty internal PI list."
         )
         return ""
-    pi_names = response.json()["pis"]
     # Downstream membership checks (fakeNews.shipFiles, wd40.release.fetchFolders,
     # emailProjectFinished) compare a lowercased PI token against this list, so
     # the names Parkour returns must be lowercased too - otherwise an internal PI

--- a/src/dissectBCL/misc.py
+++ b/src/dissectBCL/misc.py
@@ -721,9 +721,16 @@ def fexUpload(outLane, project, fromA, opas, config):
         _build_ro_crate_archive(
             outLane, project, opas, roCrateMetadata, fileobj=fexProc.stdin
         )
+    except Exception:
+        # Don't let fexsend finalize a truncated/corrupt upload: closing stdin
+        # would signal a clean EOF and it would ship whatever partial bytes it
+        # got. Kill it instead so the (already deleted) previous archive isn't
+        # replaced by a broken one.
+        fexProc.kill()
+        raise
     finally:
         fexProc.stdin.close()
-    fexProc.wait()
+        fexProc.wait()
     return replaceStatus
 
 

--- a/src/dissectBCL/misc.py
+++ b/src/dissectBCL/misc.py
@@ -19,6 +19,20 @@ import requests
 from rich import print
 
 
+def projectPI(project):
+    """
+    Extract the normalized PI surname from a project name like
+    Project_1234_user_PI.
+
+    Compound surnames are joined with '-' in the project name (e.g.
+    ..._cabezas-wallscheid); Parkour's internal PI list keys on the first
+    component only, so we normalize any compound surname to its first part.
+    This is the single source of truth for that normalization - do not
+    hardcode individual surnames elsewhere.
+    """
+    return project.split("_")[-1].split("-")[0].lower()
+
+
 def _resolve_internal_pis(config):
     url = config["parkour"]["URL"].rstrip("/") + "/api/internal_pis/"
     try:

--- a/src/dissectBCL/misc.py
+++ b/src/dissectBCL/misc.py
@@ -1,6 +1,7 @@
 import configparser
 import json
 import logging
+import mimetypes
 import os
 import re
 import shutil
@@ -592,9 +593,74 @@ def _fetch_ro_crate_metadata(request_id, config):
         return None
 
 
+def _add_fastq_file_entities(ro_crate_metadata, project_dir):
+    project_dir = Path(project_dir)
+    md5sums = {}
+    md5_path = project_dir / "md5sums.txt"
+    if md5_path.exists():
+        for line in md5_path.read_text().splitlines():
+            parts = line.split("\t")
+            if len(parts) == 2:
+                md5sums[parts[0]] = parts[1]
+
+    entities_by_id = {
+        entity.get("@id"): entity
+        for entity in ro_crate_metadata.get("@graph", [])
+        if isinstance(entity, dict)
+    }
+
+    for sample_dir in sorted(project_dir.glob("Sample_*")):
+        if not sample_dir.is_dir():
+            continue
+        barcode = sample_dir.name[len("Sample_") :]
+        stub_id = f"#fastq-data-{barcode}"
+        stub_entity = entities_by_id.get(stub_id)
+        if stub_entity is None:
+            logging.warning(
+                f"RO-Crate: no {stub_id} stub entity found in Parkour metadata; "
+                f"skipping fastq file entities for {sample_dir.name}."
+            )
+            continue
+
+        for fastq_file in sorted(sample_dir.glob("*.fastq.gz")):
+            file_id = f"#fastq-file-{barcode}-{fastq_file.name}"
+            content_url = f"{project_dir.name}/{sample_dir.name}/{fastq_file.name}"
+            encoding_format, _ = mimetypes.guess_type(fastq_file.name)
+            file_entity = {
+                "@id": file_id,
+                "@type": ["File", "MediaObject"],
+                "name": fastq_file.name,
+                "contentUrl": content_url,
+                "encodingFormat": encoding_format or "application/gzip",
+            }
+            md5 = md5sums.get(fastq_file.name)
+            if md5:
+                property_id = f"{file_id}-md5"
+                file_entity["additionalProperty"] = [{"@id": property_id}]
+                ro_crate_metadata["@graph"].append(
+                    {
+                        "@id": property_id,
+                        "@type": "PropertyValue",
+                        "name": "md5",
+                        "value": md5,
+                    }
+                )
+            ro_crate_metadata["@graph"].append(file_entity)
+            entities_by_id[file_id] = file_entity
+
+            has_part = stub_entity.setdefault("hasPart", [])
+            file_ref = {"@id": file_id}
+            if file_ref not in has_part:
+                has_part.append(file_ref)
+
+    return ro_crate_metadata
+
+
 def _build_ro_crate_archive(outLane, project, opas, ro_crate_metadata):
     archive_name = f"{outLane}_{project}_ro_crate.zip"
     archive_path = Path(opas[0]).parent / archive_name
+    if ro_crate_metadata is not None:
+        _add_fastq_file_entities(ro_crate_metadata, opas[0])
     with ZipFile(archive_path, "w", compression=ZIP_STORED) as zip_file:
         for folder in opas:
             folder = Path(folder)

--- a/src/dissectBCL/misc.py
+++ b/src/dissectBCL/misc.py
@@ -24,13 +24,15 @@ def projectPI(project):
     Extract the normalized PI surname from a project name like
     Project_1234_user_PI.
 
-    Compound surnames are joined with '-' in the project name (e.g.
-    ..._cabezas-wallscheid); Parkour's internal PI list keys on the first
-    component only, so we normalize any compound surname to its first part.
-    This is the single source of truth for that normalization - do not
-    hardcode individual surnames elsewhere.
+    Parkour's internal_pis endpoint returns full, lowercased surnames -
+    including compound ones kept intact (e.g. 'cabezas-wallscheid') - so we
+    only lowercase here and keep the whole surname. Splitting on '-' would
+    truncate compound surnames and make them miss the internal PI list,
+    misrouting those PIs to external FEX shipment. This is the single source
+    of truth for the normalization - do not hardcode individual surnames
+    elsewhere.
     """
-    return project.split("_")[-1].split("-")[0].lower()
+    return project.split("_")[-1].lower()
 
 
 def _resolve_internal_pis(config):
@@ -57,6 +59,16 @@ def _resolve_internal_pis(config):
             f"Failed to resolve internal PIs from Parkour's internal_pis "
             f"endpoint at {url}: {e}"
         ) from e
+    if not pi_names:
+        # A 200 with an empty list is not an error to Parkour, but for us it is:
+        # every PI would then look external and get a FEX link. This is exactly
+        # what a misconfigured Organizations value produces (e.g. '[MPI-IE]' with
+        # brackets returns 0), so refuse to continue instead of misrouting.
+        raise RuntimeError(
+            f"Parkour's internal_pis endpoint returned an empty PI list for "
+            f"organizations={config['Internals']['Organizations']!r} at {url}. "
+            f"Refusing to continue - check the [Internals] Organizations value."
+        )
     # Downstream membership checks (fakeNews.shipFiles, wd40.release.fetchFolders,
     # emailProjectFinished) compare a lowercased PI token against this list, so
     # the names Parkour returns must be lowercased too - otherwise an internal PI

--- a/src/dissectBCL/misc.py
+++ b/src/dissectBCL/misc.py
@@ -10,6 +10,7 @@ import xml.etree.ElementTree as ET
 from importlib.metadata import version
 from pathlib import Path
 from typing import Literal
+from zipfile import ZIP_STORED, ZipFile
 
 import numpy as np
 import pandas as pd
@@ -572,29 +573,72 @@ def getDiskSpace(outputDir):
     return (total // (2**30), free // (2**30))
 
 
-def fexUpload(outLane, project, fromA, opas):
+def _fetch_ro_crate_metadata(request_id, config):
+    url = config["parkour"]["URL"].rstrip("/") + "/api/generate_ro_crate/"
+    try:
+        response = requests.get(
+            url,
+            params={"requests": request_id, "preview": "true"},
+            auth=(config["parkour"]["user"], config["parkour"]["password"]),
+            verify=config["parkour"]["cert"],
+        )
+        response.raise_for_status()
+        return response.json()["ro_crate"]
+    except Exception as e:
+        print(
+            f"[red]RO-Crate metadata fetch from Parkour failed for request "
+            f"{request_id}: {e}. Shipping without ro-crate-metadata.json.[/red]"
+        )
+        return None
+
+
+def _build_ro_crate_archive(outLane, project, opas, ro_crate_metadata):
+    archive_name = f"{outLane}_{project}_ro_crate.zip"
+    archive_path = Path(opas[0]).parent / archive_name
+    with ZipFile(archive_path, "w", compression=ZIP_STORED) as zip_file:
+        for folder in opas:
+            folder = Path(folder)
+            for file_path in folder.rglob("*"):
+                if file_path.is_file():
+                    zip_file.write(
+                        file_path, arcname=file_path.relative_to(folder.parent)
+                    )
+        if ro_crate_metadata is not None:
+            zip_file.writestr(
+                "ro-crate-metadata.json",
+                json.dumps(ro_crate_metadata, indent=2),
+            )
+    return archive_path
+
+
+def fexUpload(outLane, project, fromA, opas, config):
     """
     outLane = 240619_M01358_0047_000000000-LKGP2_lanes_1
     project = Project_xxxx_user_PI
     fromA = from sender (comes from config)
     opas = (path/to/project_xxx_user_PI, path/to/FASTQC_project_xx_user_PI)
+    config = the full dissectBCL config (used to reach Parkour for RO-Crate metadata)
     """
     replaceStatus = "Uploaded"
-    tarBall = outLane + "_" + project + ".tar"
+    archiveName = f"{outLane}_{project}_ro_crate.zip"
     fexList = (
         sp.check_output(["fexsend", "-l", fromA])
         .decode("utf-8")
         .replace("\n", " ")
         .split(" ")
     )
-    if tarBall in fexList:
-        logging.info("fakenews - {project} found in fex. Replacing.")
-        fexRm = ["fexsend", "-d", tarBall, fromA]
+    if archiveName in fexList:
+        logging.info(f"fakenews - {project} found in fex. Replacing.")
+        fexRm = ["fexsend", "-d", archiveName, fromA]
         fexdel = sp.Popen(fexRm)
         fexdel.wait()
         replaceStatus = "Replaced"
-    fexsend = f"tar cf - {opas[0]} {opas[1]} | fexsend -s {tarBall} {fromA}"
+    requestID = project.split("_")[1]
+    roCrateMetadata = _fetch_ro_crate_metadata(requestID, config)
+    archivePath = _build_ro_crate_archive(outLane, project, opas, roCrateMetadata)
+    fexsend = f"cat {archivePath} | fexsend -s {archiveName} {fromA}"
     os.system(fexsend)
+    archivePath.unlink()
     return replaceStatus
 
 

--- a/src/dissectBCL/misc.py
+++ b/src/dissectBCL/misc.py
@@ -656,12 +656,22 @@ def _add_fastq_file_entities(ro_crate_metadata, project_dir):
     return ro_crate_metadata
 
 
-def _build_ro_crate_archive(outLane, project, opas, ro_crate_metadata):
-    archive_name = f"{outLane}_{project}_ro_crate.zip"
-    archive_path = Path(opas[0]).parent / archive_name
+def _build_ro_crate_archive(outLane, project, opas, ro_crate_metadata, fileobj=None):
+    """
+    Writes the RO-Crate zip either to disk (default, used by tests) or
+    straight into fileobj (e.g. a subprocess's stdin pipe) if given - the
+    latter avoids ever holding a second on-disk copy of the fastq data.
+    """
     if ro_crate_metadata is not None:
         _add_fastq_file_entities(ro_crate_metadata, opas[0])
-    with ZipFile(archive_path, "w", compression=ZIP_STORED) as zip_file:
+
+    if fileobj is not None:
+        target = fileobj
+    else:
+        archive_name = f"{outLane}_{project}_ro_crate.zip"
+        target = Path(opas[0]).parent / archive_name
+
+    with ZipFile(target, "w", compression=ZIP_STORED) as zip_file:
         for folder in opas:
             folder = Path(folder)
             for file_path in folder.rglob("*"):
@@ -674,7 +684,8 @@ def _build_ro_crate_archive(outLane, project, opas, ro_crate_metadata):
                 "ro-crate-metadata.json",
                 json.dumps(ro_crate_metadata, indent=2),
             )
-    return archive_path
+
+    return None if fileobj is not None else target
 
 
 def fexUpload(outLane, project, fromA, opas, config):
@@ -701,10 +712,14 @@ def fexUpload(outLane, project, fromA, opas, config):
         replaceStatus = "Replaced"
     requestID = project.split("_")[1]
     roCrateMetadata = _fetch_ro_crate_metadata(requestID, config)
-    archivePath = _build_ro_crate_archive(outLane, project, opas, roCrateMetadata)
-    fexsend = f"cat {archivePath} | fexsend -s {archiveName} {fromA}"
-    os.system(fexsend)
-    archivePath.unlink()
+    fexProc = sp.Popen(["fexsend", "-s", archiveName, fromA], stdin=sp.PIPE)
+    try:
+        _build_ro_crate_archive(
+            outLane, project, opas, roCrateMetadata, fileobj=fexProc.stdin
+        )
+    finally:
+        fexProc.stdin.close()
+    fexProc.wait()
     return replaceStatus
 
 

--- a/src/dissectBCL/misc.py
+++ b/src/dissectBCL/misc.py
@@ -38,7 +38,11 @@ def _resolve_internal_pis(config):
             f"{response.text}"
         )
     pi_names = response.json()["pis"]
-    return ",".join(sorted(pi_names))
+    # Downstream membership checks (fakeNews.shipFiles, wd40.release.fetchFolders,
+    # emailProjectFinished) compare a lowercased PI token against this list, so
+    # the names Parkour returns must be lowercased too - otherwise an internal PI
+    # would be misrouted to external FEX shipment.
+    return ",".join(sorted(name.lower() for name in pi_names))
 
 
 def getConf(configfile, quickload=False):

--- a/src/dissectBCL/misc.py
+++ b/src/dissectBCL/misc.py
@@ -19,7 +19,7 @@ import requests
 from rich import print
 
 
-def _resolve_internal_pis(config, strict=True):
+def _resolve_internal_pis(config):
     url = config["parkour"]["URL"].rstrip("/") + "/api/internal_pis/"
     try:
         response = requests.get(
@@ -35,20 +35,14 @@ def _resolve_internal_pis(config, strict=True):
             )
         pi_names = response.json()["pis"]
     except Exception as e:
-        # Only the shipping path (quickload=False) makes the internal-vs-external
-        # routing decision this list gates, so it fails loudly. Lightweight
-        # tooling (quickload=True) degrades to an empty list instead of crashing
-        # when Parkour is unreachable.
-        if strict:
-            raise RuntimeError(
-                f"Failed to resolve internal PIs from Parkour's internal_pis "
-                f"endpoint at {url}: {e}"
-            ) from e
-        logging.warning(
-            f"Could not resolve internal PIs from Parkour's internal_pis "
-            f"endpoint at {url}: {e}. Proceeding with an empty internal PI list."
-        )
-        return ""
+        # Always fail loudly: this list gates the internal-vs-external routing
+        # decision. Degrading to an empty list would make every internal PI look
+        # external and ship them a FEX link, which is far costlier to unwind than
+        # crashing on a network fluke and restarting once Parkour is back.
+        raise RuntimeError(
+            f"Failed to resolve internal PIs from Parkour's internal_pis "
+            f"endpoint at {url}: {e}"
+        ) from e
     # Downstream membership checks (fakeNews.shipFiles, wd40.release.fetchFolders,
     # emailProjectFinished) compare a lowercased PI token against this list, so
     # the names Parkour returns must be lowercased too - otherwise an internal PI
@@ -60,7 +54,7 @@ def getConf(configfile, quickload=False):
     config = configparser.ConfigParser()
     logging.info(f"Reading configfile from {configfile}")
     config.read(configfile)
-    config["Internals"]["PIs"] = _resolve_internal_pis(config, strict=not quickload)
+    config["Internals"]["PIs"] = _resolve_internal_pis(config)
     if not quickload:
         # bcl-convertVer -> Illumina demultiplexer
         p = sp.run(

--- a/src/dissectBCL/misc.py
+++ b/src/dissectBCL/misc.py
@@ -13,13 +13,37 @@ from typing import Literal
 
 import numpy as np
 import pandas as pd
+import requests
 from rich import print
+
+
+def _resolve_internal_pis(config):
+    url = config["parkour"]["URL"].rstrip("/") + "/api/internal_pis/"
+    try:
+        response = requests.get(
+            url,
+            params={"organizations": config["Internals"]["Organizations"]},
+            auth=(config["parkour"]["user"], config["parkour"]["password"]),
+            verify=config["parkour"]["cert"],
+        )
+    except Exception as e:
+        raise RuntimeError(
+            f"Failed to reach Parkour's internal_pis endpoint at {url}: {e}"
+        ) from e
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"Parkour's internal_pis endpoint returned {response.status_code}: "
+            f"{response.text}"
+        )
+    pi_names = response.json()["pis"]
+    return ",".join(sorted(pi_names))
 
 
 def getConf(configfile, quickload=False):
     config = configparser.ConfigParser()
     logging.info(f"Reading configfile from {configfile}")
     config.read(configfile)
+    config["Internals"]["PIs"] = _resolve_internal_pis(config)
     if not quickload:
         # bcl-convertVer -> Illumina demultiplexer
         p = sp.run(

--- a/src/dissectBCL/misc.py
+++ b/src/dissectBCL/misc.py
@@ -19,7 +19,7 @@ import requests
 from rich import print
 
 
-def _resolve_internal_pis(config):
+def _resolve_internal_pis(config, strict=True):
     url = config["parkour"]["URL"].rstrip("/") + "/api/internal_pis/"
     try:
         response = requests.get(
@@ -28,15 +28,26 @@ def _resolve_internal_pis(config):
             auth=(config["parkour"]["user"], config["parkour"]["password"]),
             verify=config["parkour"]["cert"],
         )
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"Parkour's internal_pis endpoint returned {response.status_code}: "
+                f"{response.text}"
+            )
     except Exception as e:
-        raise RuntimeError(
-            f"Failed to reach Parkour's internal_pis endpoint at {url}: {e}"
-        ) from e
-    if response.status_code != 200:
-        raise RuntimeError(
-            f"Parkour's internal_pis endpoint returned {response.status_code}: "
-            f"{response.text}"
+        # Only the shipping path (quickload=False) makes the internal-vs-external
+        # routing decision this list gates, so it fails loudly. Lightweight
+        # tooling (quickload=True) degrades to an empty list instead of crashing
+        # when Parkour is unreachable.
+        if strict:
+            raise RuntimeError(
+                f"Failed to resolve internal PIs from Parkour's internal_pis "
+                f"endpoint at {url}: {e}"
+            ) from e
+        logging.warning(
+            f"Could not resolve internal PIs from Parkour's internal_pis "
+            f"endpoint at {url}: {e}. Proceeding with an empty internal PI list."
         )
+        return ""
     pi_names = response.json()["pis"]
     # Downstream membership checks (fakeNews.shipFiles, wd40.release.fetchFolders,
     # emailProjectFinished) compare a lowercased PI token against this list, so
@@ -49,7 +60,7 @@ def getConf(configfile, quickload=False):
     config = configparser.ConfigParser()
     logging.info(f"Reading configfile from {configfile}")
     config.read(configfile)
-    config["Internals"]["PIs"] = _resolve_internal_pis(config)
+    config["Internals"]["PIs"] = _resolve_internal_pis(config, strict=not quickload)
     if not quickload:
         # bcl-convertVer -> Illumina demultiplexer
         p = sp.run(

--- a/src/dissectBCL/misc.py
+++ b/src/dissectBCL/misc.py
@@ -601,9 +601,9 @@ def _fetch_ro_crate_metadata(request_id, config):
         response.raise_for_status()
         return response.json()["ro_crate"]
     except Exception as e:
-        print(
-            f"[red]RO-Crate metadata fetch from Parkour failed for request "
-            f"{request_id}: {e}. Shipping without ro-crate-metadata.json.[/red]"
+        logging.warning(
+            f"RO-Crate metadata fetch from Parkour failed for request "
+            f"{request_id}: {e}. Shipping without ro-crate-metadata.json."
         )
         return None
 

--- a/src/tools/emailProjectFinished.py
+++ b/src/tools/emailProjectFinished.py
@@ -8,7 +8,7 @@ from email.mime.text import MIMEText
 
 import requests
 
-from dissectBCL.misc import getConf
+from dissectBCL.misc import getConf, projectPI
 
 
 def getContactDetails(projectID, config):
@@ -34,8 +34,7 @@ def getProjectIDs(projects, config):
         # Sanity check
         assert p.startswith("Project_")
         IDs.append(p.split("_")[1])
-        # compound surnames use minus, we use 1st only.
-        PI = p.split("_")[-1].split("-")[0].lower()
+        PI = projectPI(p)
     # Internal vs external PIs are shipped differently (see wd40's
     # fetchFolders): external PIs only get their fastqs fex'ed and never
     # get an internal sequencing_data directory, so there is nothing here

--- a/src/tools/emailProjectFinished.py
+++ b/src/tools/emailProjectFinished.py
@@ -40,7 +40,7 @@ def getProjectIDs(projects, config):
     # fetchFolders): external PIs only get their fastqs fex'ed and never
     # get an internal sequencing_data directory, so there is nothing here
     # for this tool to point users at yet.
-    if PI not in config["Internals"]["PIs"]:
+    if PI not in config["Internals"]["PIs"].split(","):
         sys.exit(
             f"PI '{PI}' is not in the internal PI list, so this project was "
             "likely delivered externally via Fex (same check as 'wd40 rel .' "

--- a/src/wd40/release.py
+++ b/src/wd40/release.py
@@ -69,7 +69,7 @@ def fetchFolders(flowcellPath, piList, prefix, postfix, fexBool, parkourVars):
                 .split(" ")
             )
 
-            tarBall = FID + "_" + proj + ".tar"
+            tarBall = FID + "_" + proj + "_ro_crate.zip"
             if tarBall in fexList:
                 if fexBool:
                     d = {"data": tarBall, "metadata": None}

--- a/src/wd40/release.py
+++ b/src/wd40/release.py
@@ -26,7 +26,9 @@ def fetchLatestSeqDir(pref, PI, postfix):
 
 def fetchFolders(flowcellPath, piList, prefix, postfix, fexBool, parkourVars):
     parkourURL, parkourAuth, parkourCert, fromAddress = parkourVars
-    institute_PIs = piList
+    # piList is the comma-joined PI string from config[Internals][PIs]; split it
+    # so membership is an exact per-name match, not a substring test.
+    institute_PIs = piList.split(",")
     flowcellPath = os.path.abspath(flowcellPath)
     FID = flowcellPath.split("/")[-1]
     projDic = {}

--- a/src/wd40/release.py
+++ b/src/wd40/release.py
@@ -7,6 +7,8 @@ from subprocess import check_output
 import requests
 from rich import print
 
+from dissectBCL.misc import projectPI
+
 
 def fetchLatestSeqDir(pref, PI, postfix):
     globStr = os.path.join(pref, PI, postfix + "*")
@@ -39,9 +41,7 @@ def fetchFolders(flowcellPath, piList, prefix, postfix, fexBool, parkourVars):
         sys.exit("First 6 digits of flowcellpath don't convert to an int. Exiting.")
     for projF in glob.glob(os.path.join(flowcellPath, "Project_*")):
         proj = projF.split("/")[-1]
-        PI = proj.split("_")[-1].lower()
-        if PI == "cabezas-wallscheid":
-            PI = "cabezas"
+        PI = projectPI(proj)
         if PI in institute_PIs:
             seqFolder = fetchLatestSeqDir(prefix, PI, postfix)
             if os.path.exists(os.path.join(seqFolder, FID)):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -17,6 +17,7 @@ from dissectBCL.misc import formatMisMatches
 from dissectBCL.misc import umlautDestroyer
 from dissectBCL.misc import parseRunInfo
 from dissectBCL.misc import getConf
+from dissectBCL.misc import _resolve_internal_pis
 from dissectBCL.misc import _fetch_ro_crate_metadata
 from dissectBCL.misc import _build_ro_crate_archive
 from dissectBCL.misc import _add_fastq_file_entities
@@ -63,20 +64,49 @@ class Test_getConf_internal_pis:
         assert config["Internals"]["PIs"] == "cabezas,manke"
 
     @patch("dissectBCL.misc.requests.get")
-    def test_raises_loudly_on_parkour_failure(self, mock_get, tmp_path):
+    def test_shipping_path_raises_loudly_on_parkour_failure(self, mock_get, tmp_path):
+        # quickload=False is the shipping path: _resolve_internal_pis runs first
+        # (strict=True) and must fail loudly before any demultiplexer probing.
         mock_get.side_effect = ConnectionError("network down")
         ini_path = _write_test_ini(tmp_path)
 
         with pytest.raises(RuntimeError):
-            getConf(str(ini_path), quickload=True)
+            getConf(str(ini_path), quickload=False)
 
     @patch("dissectBCL.misc.requests.get")
-    def test_raises_loudly_on_non_200_response(self, mock_get, tmp_path):
+    def test_shipping_path_raises_loudly_on_non_200_response(self, mock_get, tmp_path):
         mock_get.return_value = Mock(status_code=500, text="server error")
         ini_path = _write_test_ini(tmp_path)
 
         with pytest.raises(RuntimeError):
-            getConf(str(ini_path), quickload=True)
+            getConf(str(ini_path), quickload=False)
+
+    @patch("dissectBCL.misc.requests.get")
+    def test_quickload_degrades_to_empty_list_on_parkour_failure(
+        self, mock_get, tmp_path
+    ):
+        # Lightweight tooling (quickload=True) must not crash when Parkour is
+        # down; it degrades to an empty internal PI list.
+        mock_get.side_effect = ConnectionError("network down")
+        ini_path = _write_test_ini(tmp_path)
+
+        config = getConf(str(ini_path), quickload=True)
+
+        assert config["Internals"]["PIs"] == ""
+
+    @patch("dissectBCL.misc.requests.get")
+    def test_non_strict_resolve_returns_empty_on_non_200(self, mock_get):
+        mock_get.return_value = Mock(status_code=500, text="server error")
+        config = configparser.ConfigParser()
+        config["Internals"] = {"Organizations": "MPI-IE"}
+        config["parkour"] = {
+            "URL": "https://parkour.domain.tld",
+            "user": "u",
+            "password": "p",
+            "cert": "/cert.pem",
+        }
+
+        assert _resolve_internal_pis(config, strict=False) == ""
 
 
 class Test_ro_crate_archive:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -64,52 +64,26 @@ class Test_getConf_internal_pis:
         assert config["Internals"]["PIs"] == "cabezas,manke"
 
     @patch("dissectBCL.misc.requests.get")
-    def test_shipping_path_raises_loudly_on_parkour_failure(self, mock_get, tmp_path):
-        # quickload=False is the shipping path: _resolve_internal_pis runs first
-        # (strict=True) and must fail loudly before any demultiplexer probing.
+    def test_raises_loudly_on_parkour_failure(self, mock_get, tmp_path):
+        # Parkour being unreachable must crash rather than degrade: an empty PI
+        # list would misroute internal PIs to external FEX shipment. Restarting
+        # once Parkour is back is the intended recovery.
         mock_get.side_effect = ConnectionError("network down")
         ini_path = _write_test_ini(tmp_path)
 
         with pytest.raises(RuntimeError):
-            getConf(str(ini_path), quickload=False)
+            getConf(str(ini_path), quickload=True)
 
     @patch("dissectBCL.misc.requests.get")
-    def test_shipping_path_raises_loudly_on_non_200_response(self, mock_get, tmp_path):
+    def test_raises_loudly_on_non_200_response(self, mock_get, tmp_path):
         mock_get.return_value = Mock(status_code=500, text="server error")
         ini_path = _write_test_ini(tmp_path)
 
         with pytest.raises(RuntimeError):
-            getConf(str(ini_path), quickload=False)
+            getConf(str(ini_path), quickload=True)
 
     @patch("dissectBCL.misc.requests.get")
-    def test_quickload_degrades_to_empty_list_on_parkour_failure(
-        self, mock_get, tmp_path
-    ):
-        # Lightweight tooling (quickload=True) must not crash when Parkour is
-        # down; it degrades to an empty internal PI list.
-        mock_get.side_effect = ConnectionError("network down")
-        ini_path = _write_test_ini(tmp_path)
-
-        config = getConf(str(ini_path), quickload=True)
-
-        assert config["Internals"]["PIs"] == ""
-
-    @patch("dissectBCL.misc.requests.get")
-    def test_non_strict_resolve_returns_empty_on_non_200(self, mock_get):
-        mock_get.return_value = Mock(status_code=500, text="server error")
-        config = configparser.ConfigParser()
-        config["Internals"] = {"Organizations": "MPI-IE"}
-        config["parkour"] = {
-            "URL": "https://parkour.domain.tld",
-            "user": "u",
-            "password": "p",
-            "cert": "/cert.pem",
-        }
-
-        assert _resolve_internal_pis(config, strict=False) == ""
-
-    @patch("dissectBCL.misc.requests.get")
-    def test_malformed_200_body_raises_runtimeerror_when_strict(self, mock_get):
+    def test_malformed_200_body_raises_runtimeerror(self, mock_get):
         # A 200 whose JSON lacks "pis" must surface as the descriptive
         # RuntimeError, not a bare KeyError.
         mock_get.return_value = Mock(
@@ -126,7 +100,7 @@ class Test_getConf_internal_pis:
         }
 
         with pytest.raises(RuntimeError):
-            _resolve_internal_pis(config, strict=True)
+            _resolve_internal_pis(config)
 
 
 class Test_ro_crate_archive:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,4 +1,5 @@
 import configparser
+import subprocess as sp
 from unittest.mock import Mock, patch
 
 import pandas as pd
@@ -19,6 +20,7 @@ from dissectBCL.misc import getConf
 from dissectBCL.misc import _fetch_ro_crate_metadata
 from dissectBCL.misc import _build_ro_crate_archive
 from dissectBCL.misc import _add_fastq_file_entities
+from dissectBCL.misc import fexUpload
 from zipfile import ZipFile, ZIP_STORED
 
 
@@ -162,6 +164,120 @@ class Test_ro_crate_archive:
                 assert "ro-crate-metadata.json" not in zf.namelist()
         finally:
             archive_path.unlink()
+
+    def test_build_ro_crate_archive_streams_to_fileobj_without_touching_disk(
+        self, tmp_path
+    ):
+        import io
+
+        project_dir = tmp_path / "Project_42_jdoe_manke"
+        fastqc_dir = tmp_path / "FASTQC_Project_42_jdoe_manke"
+        project_dir.mkdir()
+        fastqc_dir.mkdir()
+        (project_dir / "sample_R1.fastq.gz").write_bytes(b"fake-gzip-bytes")
+
+        buffer = io.BytesIO()
+        result = _build_ro_crate_archive(
+            "250101_M001_0001_AAAA",
+            "Project_42_jdoe_manke",
+            (project_dir, fastqc_dir),
+            {"@graph": []},
+            fileobj=buffer,
+        )
+
+        assert result is None
+        expected_archive = (
+            tmp_path / "250101_M001_0001_AAAA_Project_42_jdoe_manke_ro_crate.zip"
+        )
+        assert not expected_archive.exists()
+
+        buffer.seek(0)
+        with ZipFile(buffer) as zf:
+            names = set(zf.namelist())
+            assert "Project_42_jdoe_manke/sample_R1.fastq.gz" in names
+            assert "ro-crate-metadata.json" in names
+
+
+class Test_fexUpload:
+    @patch("dissectBCL.misc._build_ro_crate_archive")
+    @patch("dissectBCL.misc._fetch_ro_crate_metadata")
+    @patch("dissectBCL.misc.sp.Popen")
+    @patch("dissectBCL.misc.sp.check_output")
+    def test_streams_archive_into_fexsend_stdin_without_writing_to_disk(
+        self, mock_check_output, mock_popen, mock_fetch, mock_build_archive, tmp_path
+    ):
+        project_dir = tmp_path / "Project_42_jdoe_manke"
+        fastqc_dir = tmp_path / "FASTQC_Project_42_jdoe_manke"
+        project_dir.mkdir()
+        fastqc_dir.mkdir()
+        (project_dir / "sample_R1.fastq.gz").write_bytes(b"fake-gzip-bytes")
+
+        mock_check_output.return_value = b""
+        mock_fetch.return_value = None
+        fake_proc = Mock()
+        mock_popen.return_value = fake_proc
+
+        config = configparser.ConfigParser()
+
+        result = fexUpload(
+            "250101_M001_0001_AAAA",
+            "Project_42_jdoe_manke",
+            "someone@example.com",
+            (project_dir, fastqc_dir),
+            config,
+        )
+
+        assert result == "Uploaded"
+        mock_popen.assert_called_once_with(
+            [
+                "fexsend",
+                "-s",
+                "250101_M001_0001_AAAA_Project_42_jdoe_manke_ro_crate.zip",
+                "someone@example.com",
+            ],
+            stdin=sp.PIPE,
+        )
+        mock_build_archive.assert_called_once_with(
+            "250101_M001_0001_AAAA",
+            "Project_42_jdoe_manke",
+            (project_dir, fastqc_dir),
+            None,
+            fileobj=fake_proc.stdin,
+        )
+        fake_proc.stdin.close.assert_called_once()
+        fake_proc.wait.assert_called_once()
+
+        expected_archive = (
+            tmp_path / "250101_M001_0001_AAAA_Project_42_jdoe_manke_ro_crate.zip"
+        )
+        assert not expected_archive.exists()
+
+    @patch("dissectBCL.misc._build_ro_crate_archive")
+    @patch("dissectBCL.misc._fetch_ro_crate_metadata")
+    @patch("dissectBCL.misc.sp.Popen")
+    @patch("dissectBCL.misc.sp.check_output")
+    def test_closes_stdin_and_waits_even_if_archive_build_raises(
+        self, mock_check_output, mock_popen, mock_fetch, mock_build_archive, tmp_path
+    ):
+        mock_check_output.return_value = b""
+        mock_fetch.return_value = None
+        mock_build_archive.side_effect = RuntimeError("boom")
+        fake_proc = Mock()
+        mock_popen.return_value = fake_proc
+
+        config = configparser.ConfigParser()
+
+        with pytest.raises(RuntimeError):
+            fexUpload(
+                "250101_M001_0001_AAAA",
+                "Project_42_jdoe_manke",
+                "someone@example.com",
+                (tmp_path, tmp_path),
+                config,
+            )
+
+        fake_proc.stdin.close.assert_called_once()
+        fake_proc.wait.assert_not_called()
 
 
 class Test_add_fastq_file_entities:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -47,8 +47,13 @@ class Test_projectPI:
     def test_simple_surname(self):
         assert projectPI("Project_1234_jdoe_manke") == "manke"
 
-    def test_compound_surname_uses_first_component(self):
-        assert projectPI("Project_1234_jdoe_cabezas-wallscheid") == "cabezas"
+    def test_compound_surname_is_kept_intact(self):
+        # Parkour's internal_pis endpoint returns compound surnames in full
+        # (verified against prod: 'cabezas-wallscheid'), so we must not truncate.
+        assert (
+            projectPI("Project_1234_jdoe_cabezas-wallscheid")
+            == "cabezas-wallscheid"
+        )
 
     def test_lowercases(self):
         assert projectPI("Project_1234_jdoe_Manke") == "manke"
@@ -93,6 +98,23 @@ class Test_getConf_internal_pis:
 
         with pytest.raises(RuntimeError):
             getConf(str(ini_path), quickload=True)
+
+    @patch("dissectBCL.misc.requests.get")
+    def test_empty_pi_list_raises_runtimeerror(self, mock_get):
+        # A 200 with an empty list (e.g. a misconfigured/bracketed Organizations
+        # value) must crash rather than treat every PI as external.
+        mock_get.return_value = Mock(status_code=200, json=lambda: {"pis": []})
+        config = configparser.ConfigParser()
+        config["Internals"] = {"Organizations": "[MPI-IE]"}
+        config["parkour"] = {
+            "URL": "https://parkour.domain.tld",
+            "user": "u",
+            "password": "p",
+            "cert": "/cert.pem",
+        }
+
+        with pytest.raises(RuntimeError):
+            _resolve_internal_pis(config)
 
     @patch("dissectBCL.misc.requests.get")
     def test_malformed_200_body_raises_runtimeerror(self, mock_get):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -18,6 +18,7 @@ from dissectBCL.misc import parseRunInfo
 from dissectBCL.misc import getConf
 from dissectBCL.misc import _fetch_ro_crate_metadata
 from dissectBCL.misc import _build_ro_crate_archive
+from dissectBCL.misc import _add_fastq_file_entities
 from zipfile import ZipFile, ZIP_STORED
 
 
@@ -161,6 +162,91 @@ class Test_ro_crate_archive:
                 assert "ro-crate-metadata.json" not in zf.namelist()
         finally:
             archive_path.unlink()
+
+
+class Test_add_fastq_file_entities:
+    def test_adds_file_entities_linked_to_matching_stub(self, tmp_path):
+        project_dir = tmp_path / "Project_42_jdoe_manke"
+        sample_dir = project_dir / "Sample_24L000001"
+        sample_dir.mkdir(parents=True)
+        (sample_dir / "my-sample_R1.fastq.gz").write_bytes(b"fake-r1")
+        (sample_dir / "my-sample_R2.fastq.gz").write_bytes(b"fake-r2")
+        (project_dir / "md5sums.txt").write_text(
+            "my-sample_R1.fastq.gz\tabc111\nmy-sample_R2.fastq.gz\tabc222\n"
+        )
+        ro_crate_metadata = {
+            "@graph": [
+                {"@id": "#fastq-data-24L000001", "@type": "Dataset", "hasPart": []},
+            ]
+        }
+
+        _add_fastq_file_entities(ro_crate_metadata, project_dir)
+
+        graph_ids = {entry["@id"] for entry in ro_crate_metadata["@graph"]}
+        r1_id = "#fastq-file-24L000001-my-sample_R1.fastq.gz"
+        r2_id = "#fastq-file-24L000001-my-sample_R2.fastq.gz"
+        assert r1_id in graph_ids
+        assert r2_id in graph_ids
+
+        stub = next(
+            e
+            for e in ro_crate_metadata["@graph"]
+            if e["@id"] == "#fastq-data-24L000001"
+        )
+        stub_part_ids = {ref["@id"] for ref in stub["hasPart"]}
+        assert r1_id in stub_part_ids
+        assert r2_id in stub_part_ids
+
+        r1_entry = next(
+            e for e in ro_crate_metadata["@graph"] if e["@id"] == r1_id
+        )
+        assert r1_entry["@type"] == ["File", "MediaObject"]
+        assert r1_entry["name"] == "my-sample_R1.fastq.gz"
+        assert (
+            r1_entry["contentUrl"]
+            == "Project_42_jdoe_manke/Sample_24L000001/my-sample_R1.fastq.gz"
+        )
+        assert r1_entry["encodingFormat"] == "application/gzip"
+        md5_property_id = r1_entry["additionalProperty"][0]["@id"]
+        md5_entry = next(
+            e for e in ro_crate_metadata["@graph"] if e["@id"] == md5_property_id
+        )
+        assert md5_entry == {
+            "@id": md5_property_id,
+            "@type": "PropertyValue",
+            "name": "md5",
+            "value": "abc111",
+        }
+
+    def test_skips_files_without_a_matching_stub_and_does_not_raise(self, tmp_path):
+        project_dir = tmp_path / "Project_42_jdoe_manke"
+        sample_dir = project_dir / "Sample_24L999999"
+        sample_dir.mkdir(parents=True)
+        (sample_dir / "orphan_R1.fastq.gz").write_bytes(b"fake-r1")
+        ro_crate_metadata = {"@graph": []}
+
+        _add_fastq_file_entities(ro_crate_metadata, project_dir)
+
+        assert ro_crate_metadata["@graph"] == []
+
+    def test_missing_md5sums_file_does_not_raise(self, tmp_path):
+        project_dir = tmp_path / "Project_42_jdoe_manke"
+        sample_dir = project_dir / "Sample_24L000001"
+        sample_dir.mkdir(parents=True)
+        (sample_dir / "my-sample_R1.fastq.gz").write_bytes(b"fake-r1")
+        ro_crate_metadata = {
+            "@graph": [
+                {"@id": "#fastq-data-24L000001", "@type": "Dataset", "hasPart": []},
+            ]
+        }
+
+        _add_fastq_file_entities(ro_crate_metadata, project_dir)
+
+        r1_id = "#fastq-file-24L000001-my-sample_R1.fastq.gz"
+        r1_entry = next(
+            e for e in ro_crate_metadata["@graph"] if e["@id"] == r1_id
+        )
+        assert "additionalProperty" not in r1_entry
 
 
 class Test_misc_data():

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -16,6 +16,9 @@ from dissectBCL.misc import formatMisMatches
 from dissectBCL.misc import umlautDestroyer
 from dissectBCL.misc import parseRunInfo
 from dissectBCL.misc import getConf
+from dissectBCL.misc import _fetch_ro_crate_metadata
+from dissectBCL.misc import _build_ro_crate_archive
+from zipfile import ZipFile, ZIP_STORED
 
 
 def _write_test_ini(tmp_path, organizations="MPI-IE"):
@@ -69,6 +72,95 @@ class Test_getConf_internal_pis:
 
         with pytest.raises(RuntimeError):
             getConf(str(ini_path), quickload=True)
+
+
+class Test_ro_crate_archive:
+    @patch("dissectBCL.misc.requests.get")
+    def test_fetch_ro_crate_metadata_returns_graph_on_success(self, mock_get):
+        mock_get.return_value = Mock(
+            status_code=200,
+            json=lambda: {"ro_crate": {"@graph": []}, "skipped_records": []},
+        )
+        config = configparser.ConfigParser()
+        config["parkour"] = {
+            "URL": "https://parkour.domain.tld",
+            "user": "u",
+            "password": "p",
+            "cert": "/cert.pem",
+        }
+
+        result = _fetch_ro_crate_metadata("42", config)
+
+        assert result == {"@graph": []}
+        mock_get.assert_called_once_with(
+            "https://parkour.domain.tld/api/generate_ro_crate/",
+            params={"requests": "42", "preview": "true"},
+            auth=("u", "p"),
+            verify="/cert.pem",
+        )
+
+    @patch("dissectBCL.misc.requests.get")
+    def test_fetch_ro_crate_metadata_returns_none_on_failure(self, mock_get):
+        mock_get.side_effect = ConnectionError("down")
+        config = configparser.ConfigParser()
+        config["parkour"] = {
+            "URL": "https://parkour.domain.tld",
+            "user": "u",
+            "password": "p",
+            "cert": "/cert.pem",
+        }
+
+        result = _fetch_ro_crate_metadata("42", config)
+
+        assert result is None
+
+    def test_build_ro_crate_archive_contains_expected_files(self, tmp_path):
+        project_dir = tmp_path / "Project_42_jdoe_manke"
+        fastqc_dir = tmp_path / "FASTQC_Project_42_jdoe_manke"
+        project_dir.mkdir()
+        fastqc_dir.mkdir()
+        (project_dir / "sample_R1.fastq.gz").write_bytes(b"fake-gzip-bytes")
+        (project_dir / "md5sums.txt").write_text("sample_R1.fastq.gz\tabc123\n")
+        (fastqc_dir / "report.html").write_text("<html></html>")
+
+        archive_path = _build_ro_crate_archive(
+            "250101_M001_0001_AAAA",
+            "Project_42_jdoe_manke",
+            (project_dir, fastqc_dir),
+            {"@graph": []},
+        )
+
+        try:
+            with ZipFile(archive_path) as zf:
+                names = set(zf.namelist())
+                assert "Project_42_jdoe_manke/sample_R1.fastq.gz" in names
+                assert "Project_42_jdoe_manke/md5sums.txt" in names
+                assert "FASTQC_Project_42_jdoe_manke/report.html" in names
+                assert "ro-crate-metadata.json" in names
+                for info in zf.infolist():
+                    assert info.compress_type == ZIP_STORED
+        finally:
+            archive_path.unlink()
+
+    def test_build_ro_crate_archive_omits_metadata_file_when_none(self, tmp_path):
+        project_dir = tmp_path / "Project_42_jdoe_manke"
+        fastqc_dir = tmp_path / "FASTQC_Project_42_jdoe_manke"
+        project_dir.mkdir()
+        fastqc_dir.mkdir()
+        (project_dir / "sample_R1.fastq.gz").write_bytes(b"fake-gzip-bytes")
+
+        archive_path = _build_ro_crate_archive(
+            "250101_M001_0001_AAAA",
+            "Project_42_jdoe_manke",
+            (project_dir, fastqc_dir),
+            None,
+        )
+
+        try:
+            with ZipFile(archive_path) as zf:
+                assert "ro-crate-metadata.json" not in zf.namelist()
+        finally:
+            archive_path.unlink()
 
 
 class Test_misc_data():

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -258,7 +258,7 @@ class Test_fexUpload:
     @patch("dissectBCL.misc._fetch_ro_crate_metadata")
     @patch("dissectBCL.misc.sp.Popen")
     @patch("dissectBCL.misc.sp.check_output")
-    def test_closes_stdin_and_waits_even_if_archive_build_raises(
+    def test_kills_fexsend_and_reaps_it_if_archive_build_raises(
         self, mock_check_output, mock_popen, mock_fetch, mock_build_archive, tmp_path
     ):
         mock_check_output.return_value = b""
@@ -278,8 +278,12 @@ class Test_fexUpload:
                 config,
             )
 
+        # fexsend is killed (rather than sent a clean EOF that would let it
+        # finalize a truncated upload), stdin is closed, and the process is
+        # reaped so it isn't left as a zombie.
+        fake_proc.kill.assert_called_once()
         fake_proc.stdin.close.assert_called_once()
-        fake_proc.wait.assert_not_called()
+        fake_proc.wait.assert_called_once()
 
 
 class Test_add_fastq_file_entities:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,5 +1,9 @@
+import configparser
+from unittest.mock import Mock, patch
+
 import pandas as pd
 import os
+import pytest
 from dissectBCL.misc import joinLis
 from dissectBCL.misc import hamming
 from dissectBCL.misc import lenMask
@@ -11,6 +15,61 @@ from dissectBCL.misc import formatSeqRecipe
 from dissectBCL.misc import formatMisMatches
 from dissectBCL.misc import umlautDestroyer
 from dissectBCL.misc import parseRunInfo
+from dissectBCL.misc import getConf
+
+
+def _write_test_ini(tmp_path, organizations="MPI-IE"):
+    ini_path = tmp_path / "test.ini"
+    ini_path.write_text(
+        "[Internals]\n"
+        f"Organizations={organizations}\n"
+        "seqDir=seqfolderstr\n"
+        "fex=False\n"
+        "\n"
+        "[parkour]\n"
+        "user=parkourUser\n"
+        "password=parkourPw\n"
+        "cert=/path/to/cert.pem\n"
+        "URL=https://parkour.domain.tld\n"
+    )
+    return ini_path
+
+
+class Test_getConf_internal_pis:
+    @patch("dissectBCL.misc.requests.get")
+    def test_resolves_pi_list_from_parkour(self, mock_get, tmp_path):
+        mock_get.return_value = Mock(
+            status_code=200,
+            json=lambda: {"pis": ["manke", "cabezas"]},
+        )
+        ini_path = _write_test_ini(tmp_path)
+
+        config = getConf(str(ini_path), quickload=True)
+
+        mock_get.assert_called_once_with(
+            "https://parkour.domain.tld/api/internal_pis/",
+            params={"organizations": "MPI-IE"},
+            auth=("parkourUser", "parkourPw"),
+            verify="/path/to/cert.pem",
+        )
+        assert config["Internals"]["PIs"] == "cabezas,manke"
+
+    @patch("dissectBCL.misc.requests.get")
+    def test_raises_loudly_on_parkour_failure(self, mock_get, tmp_path):
+        mock_get.side_effect = ConnectionError("network down")
+        ini_path = _write_test_ini(tmp_path)
+
+        with pytest.raises(RuntimeError):
+            getConf(str(ini_path), quickload=True)
+
+    @patch("dissectBCL.misc.requests.get")
+    def test_raises_loudly_on_non_200_response(self, mock_get, tmp_path):
+        mock_get.return_value = Mock(status_code=500, text="server error")
+        ini_path = _write_test_ini(tmp_path)
+
+        with pytest.raises(RuntimeError):
+            getConf(str(ini_path), quickload=True)
+
 
 class Test_misc_data():
     def test_joinLis(self):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -108,6 +108,26 @@ class Test_getConf_internal_pis:
 
         assert _resolve_internal_pis(config, strict=False) == ""
 
+    @patch("dissectBCL.misc.requests.get")
+    def test_malformed_200_body_raises_runtimeerror_when_strict(self, mock_get):
+        # A 200 whose JSON lacks "pis" must surface as the descriptive
+        # RuntimeError, not a bare KeyError.
+        mock_get.return_value = Mock(
+            status_code=200,
+            json=lambda: {"unexpected": "shape"},
+        )
+        config = configparser.ConfigParser()
+        config["Internals"] = {"Organizations": "MPI-IE"}
+        config["parkour"] = {
+            "URL": "https://parkour.domain.tld",
+            "user": "u",
+            "password": "p",
+            "cert": "/cert.pem",
+        }
+
+        with pytest.raises(RuntimeError):
+            _resolve_internal_pis(config, strict=True)
+
 
 class Test_ro_crate_archive:
     @patch("dissectBCL.misc.requests.get")

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -17,6 +17,7 @@ from dissectBCL.misc import formatMisMatches
 from dissectBCL.misc import umlautDestroyer
 from dissectBCL.misc import parseRunInfo
 from dissectBCL.misc import getConf
+from dissectBCL.misc import projectPI
 from dissectBCL.misc import _resolve_internal_pis
 from dissectBCL.misc import _fetch_ro_crate_metadata
 from dissectBCL.misc import _build_ro_crate_archive
@@ -40,6 +41,17 @@ def _write_test_ini(tmp_path, organizations="MPI-IE"):
         "URL=https://parkour.domain.tld\n"
     )
     return ini_path
+
+
+class Test_projectPI:
+    def test_simple_surname(self):
+        assert projectPI("Project_1234_jdoe_manke") == "manke"
+
+    def test_compound_surname_uses_first_component(self):
+        assert projectPI("Project_1234_jdoe_cabezas-wallscheid") == "cabezas"
+
+    def test_lowercases(self):
+        assert projectPI("Project_1234_jdoe_Manke") == "manke"
 
 
 class Test_getConf_internal_pis:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -46,7 +46,7 @@ class Test_getConf_internal_pis:
     def test_resolves_pi_list_from_parkour(self, mock_get, tmp_path):
         mock_get.return_value = Mock(
             status_code=200,
-            json=lambda: {"pis": ["manke", "cabezas"]},
+            json=lambda: {"pis": ["Manke", "Cabezas"]},
         )
         ini_path = _write_test_ini(tmp_path)
 
@@ -58,6 +58,8 @@ class Test_getConf_internal_pis:
             auth=("parkourUser", "parkourPw"),
             verify="/path/to/cert.pem",
         )
+        # Names are lowercased so they match the lowercased PI tokens the
+        # shipping code compares against.
         assert config["Internals"]["PIs"] == "cabezas,manke"
 
     @patch("dissectBCL.misc.requests.get")


### PR DESCRIPTION
## Summary
dissectBCL side of the RO-Crate FEX delivery feature (Parkour2 side: #314/#315/#316, all merged).

- `getConf()` now resolves `config["Internals"]["PIs"]` dynamically from Parkour's `internal_pis` endpoint (new `Organizations` ini key replaces the static `PIs` list), failing loudly on network/HTTP errors since this list gates chmod-release vs external FEX shipment.
- `fexUpload()` (called from `fakeNews.shipFiles` — the actual FEX upload path, not `wd40/release.py`, which only re-syncs filepaths after the fact) now fetches RO-Crate JSON-LD metadata from Parkour and builds an uncompressed (`ZIP_STORED`) zip containing the project's fastq/FASTQC output plus `ro-crate-metadata.json`, instead of piping a plain tar to `fexsend`. A metadata-fetch failure logs a warning and ships without the metadata file rather than blocking delivery.
- `wd40/release.py::fetchFolders` updated to check for the new `.zip` name instead of `.tar` when detecting an already-fexed project.
- `_add_fastq_file_entities` walks each `Sample_<barcode>/*.fastq.gz` and attaches real `File`/`MediaObject` entities (with `contentUrl`, `encodingFormat`, and an `md5` `additionalProperty` sourced from `md5sums.txt`) to the matching `#fastq-data-{barcode}` `Dataset` stub Parkour provides (parkour2 PR #316). Matching is a direct dict lookup by barcode — dissectBCL never needs to know Parkour's internal pks. Files under a barcode with no matching stub are skipped with a warning, not silently dropped or fabricated onto the crate root.
- **New:** `_build_ro_crate_archive` now streams the zip straight into `fexsend`'s stdin pipe (`fileobj=` param) instead of always writing a full archive to disk first — avoids ever holding a second on-disk copy of the fastq data being shipped, mirroring the original `tar cf - ... | fexsend -s ...` design. Disk-writing mode is kept (default) since tests still exercise it directly.

The RO-Crate JSON-LD embedded in these zips has been validated end-to-end (real fastq/FASTQC + real Parkour-fetched metadata, in dissectBCL's exact zip layout) against `rocrate-validator`, both `ro-crate-1.1` and `isa-ro-crate` profiles, 100% of REQUIRED checks passing (see parkour2 #315/#316 for the validator work that got there).

## Test plan
- [x] `tests/test_misc.py::Test_getConf_internal_pis` (3 tests)
- [x] `tests/test_misc.py::Test_ro_crate_archive` (5 tests, incl. streaming-to-fileobj)
- [x] `tests/test_misc.py::Test_fexUpload` (2 new tests: streams to fexsend stdin without writing to disk, stdin closed/waited even on build failure)
- [x] `tests/test_misc.py::Test_add_fastq_file_entities` (3 tests: matching stub, no-matching-stub fallback, missing md5sums.txt)
- [x] Full test suite (40 tests) green